### PR TITLE
Filter timer_data metrics flushed to the backend

### DIFF
--- a/exampleConfig.js
+++ b/exampleConfig.js
@@ -12,7 +12,7 @@ Optional Variables:
 
   backends:         an array of backends to load. Each backend must exist
                     by name in the directory backends/. If not specified,
-                    the default graphite backend will be loaded. 
+                    the default graphite backend will be loaded.
                     * example for console and graphite:
                     [ "./backends/console", "./backends/graphite" ]
   server:           the server to load. The server must exist by name in the directory
@@ -56,6 +56,7 @@ Optional Variables:
   keyNameSanitize:  sanitize all stat names on ingress [default: true]
                     If disabled, it is up to the backends to sanitize keynames
                     as appropriate per their storage requirements.
+  whitelistFlush:   List of aggregate metrics that can be flushed to the backend. [default: ["count", "count_ps", "mean", "upper", "lower"]]
 
   console:
     prettyprint:    whether to prettyprint the console backend
@@ -109,4 +110,5 @@ Optional Variables:
 , graphiteHost: "graphite.example.com"
 , port: 8125
 , backends: [ "./backends/graphite" ]
+, whitelistFlush: ["count", "count_ps", "mean", "upper", "lower"]
 }

--- a/stats.js
+++ b/stats.js
@@ -149,9 +149,24 @@ function flushMetrics() {
   });
 
   pm.process_metrics(metrics_hash, flushInterval, time_stamp, function emitFlush(metrics) {
-    backendEvents.emit('flush', time_stamp, metrics);
+      backendEvents.emit('flush', time_stamp, whitelistFlush(metrics));
   });
 
+}
+
+// apply a filter to the metrics that will be flushed to the backend
+// to remove metrics and are not included in the configuration: config.whitelistFlush
+function whitelistFlush(metrics) {
+    if (conf.whitelistFlush) {
+        for (var metric in metrics.timer_data) {
+            for (var key in metrics.timer_data[metric]) {
+                if (conf.whitelistFlush.indexOf(key) < 0) {
+                    delete metrics.timer_data[metric][key];
+                }
+            }
+        }
+    }
+    return metrics;
 }
 
 var stats = {

--- a/stats.js
+++ b/stats.js
@@ -155,13 +155,13 @@ function flushMetrics() {
 }
 
 // apply a filter to the metrics that will be flushed to the backend
-// to remove metrics and are not included in the configuration: config.whitelistFlush
+// to remove metrics that are not included in the configuration: config.whitelistFlush
 function whitelistFlush(metrics) {
     if (conf.whitelistFlush) {
         for (var metric in metrics.timer_data) {
             for (var key in metrics.timer_data[metric]) {
                 if (conf.whitelistFlush.indexOf(key) < 0) {
-                    delete metrics.timer_data[metric][key];
+                    delete(metrics.timer_data[metric][key]);
                 }
             }
         }


### PR DESCRIPTION
Allow the configuration of a whitelist of metrics to be flushed to the backend
